### PR TITLE
Using deb branch as per knxd developers updated branching strategy

### DIFF
--- a/knxd/Dockerfile
+++ b/knxd/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
                 udev \
                 libusb \
                 libev \
-     && git clone -b stable https://github.com/knxd/knxd.git \
+     && git clone -b deb https://github.com/knxd/knxd.git \
      && cd knxd \
      && ./bootstrap.sh \
      && ./configure --disable-systemd --enable-tpuart --enable-usb --enable-eibnetipserver --enable-eibnetip --enable-eibnetserver --enable-eibnetiptunnel \


### PR DESCRIPTION
After version 0.14.34 of the master branch of knxd Debian packages are no longer used. To build for debian the deb branch should be used, as described here https://github.com/knxd/knxd

The dockerfile is updated to reflect that. As per https://community.home-assistant.io/t/knxd-add-on-covert-your-knx-usb-interface-into-an-ip-interface-that-can-be-used-by-ha/38108/56 the user michelde has already tried and succeded in building from deb branch.