### PR TITLE
[Bugfix] fix compilation of stable branch of KNXD until they fixed thier build script

### DIFF
--- a/knxd/Dockerfile
+++ b/knxd/Dockerfile
@@ -28,6 +28,8 @@ RUN set -xe \
                 libev \
      && git clone -b "${KNXD_BRANCH}" --depth 1 https://github.com/knxd/knxd.git \
      && cd knxd \
+     && mkdir -p debian \
+     && touch debian/changelog \
      && ./bootstrap.sh \
      && ./configure --disable-systemd --enable-tpuart --enable-usb --enable-eibnetipserver --enable-eibnetip --enable-eibnetserver --enable-eibnetiptunnel \
      && mkdir -p src/include/sys && ln -s /usr/lib/bcc/include/sys/cdefs.h src/include/sys \

--- a/knxd/config.json
+++ b/knxd/config.json
@@ -1,6 +1,6 @@
 {
   "name": "KNXD daemon",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "slug": "knxd",
   "description": "KNXD daemon you can use to create a KNX/IP gateway via TPUART or USB bus adapters",
   "startup": "services",


### PR DESCRIPTION
Alternative to PR #7 in order to fix the current build issues of the stable branch of knxd after they moved the debian build instructions into it's own branch and broke the build scripts on other platforms along the way.