### PR TITLE
Added host_network to docker container for multicasting

### DIFF
--- a/knxd/config.json
+++ b/knxd/config.json
@@ -14,6 +14,7 @@
   "boot": "auto",
   "hassio_api": false,
   "hassio_role": "default",
+  "host_network": true,
   "privileged": [
     "SYS_MODULE",
     "SYS_RAWIO"


### PR DESCRIPTION
Maps host network driver to knxd docker container to allow programming and multicasting.
Ref issue #9 

Tested with hassio 0.109.6 on a raspberry pi 3 for a couple of days now and works as expected

Whats tested:
- ETS4 programming
- Gira Homeserver multicast access
- homeassistant knx integration